### PR TITLE
请升级com.google.code.gson:gson组件版本以解决1个安全漏洞

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -165,7 +165,7 @@
         <bouncycastle-bcprov_version>1.68</bouncycastle-bcprov_version>
         <metrics_version>2.0.1</metrics_version>
         <sofa_registry_version>5.2.0</sofa_registry_version>
-        <gson_version>2.8.5</gson_version>
+        <gson_version>2.8.7</gson_version>
         <jsonrpc_version>1.2.0</jsonrpc_version>
         <mortbay_jetty_version>6.1.26</mortbay_jetty_version>
         <portlet_version>2.0</portlet_version>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -165,7 +165,7 @@
         <bouncycastle-bcprov_version>1.68</bouncycastle-bcprov_version>
         <metrics_version>2.0.1</metrics_version>
         <sofa_registry_version>5.2.0</sofa_registry_version>
-        <gson_version>2.8.7</gson_version>
+        <gson_version>2.8.9</gson_version>
         <jsonrpc_version>1.2.0</jsonrpc_version>
         <mortbay_jetty_version>6.1.26</mortbay_jetty_version>
         <portlet_version>2.0</portlet_version>


### PR DESCRIPTION
将 **com.google.code.gson:gson** 组件从2.8.7 版本升级至 2.8.9版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2022-12287](https://www.oscs1024.com/hd/MPS-2022-12287) | com.google.code.gson:gson 存在BigDecimal拒绝服务漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
